### PR TITLE
Change split strings to byte arrays for drive detection

### DIFF
--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -173,8 +173,8 @@ def get_drives():
         r = subprocess.check_output(["wmic", "PATH", "Win32_LogicalDisk",
                                      "get", "DeviceID,", "VolumeName,",
                                      "FileSystem,", "DriveType"])
-        for line in r.split('\n'):
-            words = re.split('\s+', line)
+        for line in r.split(b'\n'):
+            words = re.split(b'\s+', line)
             if len(words) >= 3 and words[1] == "2" and words[2] == "FAT":
                 drives.append(words[0])
     else:


### PR DESCRIPTION
Using python 3.7.2 on Windows 10 (version 1803, build 17134.472, and running in Bootcamp) I repeatedly got the following error:

```
Converting to uf2, output size: 50176, start address: 0x8000000
Traceback (most recent call last):
  File "uf2conv.py", line 292, in <module>
    main()
  File "uf2conv.py", line 279, in main
    drives = get_drives()
  File "uf2conv.py", line 176, in get_drives
    for line in r.split('\n'):
TypeError: a bytes-like object is required, not 'str'
```
As well as a similar error for the regular expressions split line immediately following. Changing the split strings to byte array objects solved the problem for me, as shown in this commit