### PR TITLE
uf2conv: eliminate trailing dot on filename

### DIFF
--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -217,7 +217,7 @@ def list_drives():
 def write_file(name, buf):
     with open(name, "wb") as f:
         f.write(buf)
-    print("Wrote %d bytes to %s." % (len(buf), name))
+    print("Wrote %d bytes to %s" % (len(buf), name))
 
 
 def main():


### PR DESCRIPTION
This trailing dot makes it less convenient to copy-and-paste the uf2 filename into other terminal commands.