### PR TITLE
uf2conv.py: Fix O(n^2) concatenation in convert_to_uf2 and convert_from_uf2

### DIFF
--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -59,7 +59,7 @@ def convert_from_uf2(buf):
     global appstartaddr
     numblocks = len(buf) // 512
     curraddr = None
-    outp = b""
+    outp = []
     for blockno in range(numblocks):
         ptr = blockno * 512
         block = buf[ptr:ptr + 512]
@@ -87,9 +87,9 @@ def convert_from_uf2(buf):
         while padding > 0:
             padding -= 4
             outp += b"\x00\x00\x00\x00"
-        outp += block[32 : 32 + datalen]
+        outp.append(block[32 : 32 + datalen])
         curraddr = newaddr + datalen
-    return outp
+    return b"".join(outp)
 
 def convert_to_carray(file_content):
     outp = "const unsigned char bindata[] __attribute__((aligned(16))) = {"
@@ -106,7 +106,7 @@ def convert_to_uf2(file_content):
     while len(datapadding) < 512 - 256 - 32 - 4:
         datapadding += b"\x00\x00\x00\x00"
     numblocks = (len(file_content) + 255) // 256
-    outp = b""
+    outp = []
     for blockno in range(numblocks):
         ptr = 256 * blockno
         chunk = file_content[ptr:ptr + 256]
@@ -120,8 +120,8 @@ def convert_to_uf2(file_content):
             chunk += b"\x00"
         block = hd + chunk + datapadding + struct.pack(b"<I", UF2_MAGIC_END)
         assert len(block) == 512
-        outp += block
-    return outp
+        outp.append(block)
+    return b"".join(outp)
 
 class Block:
     def __init__(self, addr):


### PR DESCRIPTION
I've been using `uf2conv.py` for some bootloader experiments because it's a nice tool with a great command line interface. I noticed it gets very slow (> linearly) with large files. Here is a quick repro (on Python 3.8.5):

```bash
$ cd uf2/utils
$ dd if=/dev/urandom of=rand.bin bs=16M count=1
$ time python3 uf2conv.py rand.bin -o rand.uf2
Converting to uf2, output size: 33554432, start address: 0x2000
Wrote 33554432 bytes to rand.uf2

real	4m30.839s
user	1m45.575s
sys	2m44.299s
```

This patch replaces the repeated concatenation of `bytes` objects in `convert_to_uf2()` and `convert_from_uf2()` with a `b"".join()`:

```bash
$ git checkout fix_byte_concat 
$ time python3 uf2conv.py rand.bin -o rand.uf2
Converting to uf2, output size: 33554432, start address: 0x2000
Wrote 33554432 bytes to rand.uf2

real	0m0.267s
user	0m0.160s
sys	0m0.089s
```

I realise that the performance of the Python-based version of the tool might not be of the highest concern, but this is a fairly small change, and makes a big difference.