### PR TITLE
Add family IDs for missing chips of Espressif

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,10 @@ This procedure was unfortunately not used for the SAMD51 and NRF52840 below.
 * ST STM32WLxx - 0x21460ff0
 * Microchip (Atmel) ATmega32 - 0x16573617
 * Cypress FX2 - 0x5a18069b
+* ESP8266 - 0x7eab61ed
 * ESP32 - 0x1c5f21b0
+* ESP32-S2 - 0x70c5997a
+* ESP32-C3 - 0xd42ba06c
 * NXP i.MX RT10XX - 0x4fb2d5bd
 * GD32F350 - 0x31d228c6
 


### PR DESCRIPTION
The IDs were generated randomly with https://microsoft.github.io/uf2/patcher/.