### PR TITLE
add ESP32S2 family ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ This procedure was unfortunately not used for the SAMD51 and NRF52840 below.
 * Cypress FX2 - 0x5a18069b
 * ESP8266 - 0x7eab61ed
 * ESP32 - 0x1c5f21b0
-* ESP32-S2 - 0x70c5997a
+* ESP32-S2 - 0xbfdd4eee
 * ESP32-C3 - 0xd42ba06c
 * NXP i.MX RT10XX - 0x4fb2d5bd
 * GD32F350 - 0x31d228c6

--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -34,7 +34,8 @@ families = {
     'STM32WL': 0x21460ff0,
     'ATMEGA32': 0x16573617,
     'MIMXRT10XX': 0x4FB2D5BD,
-    'GD32F350': 0x31D228C6
+    'GD32F350': 0x31D228C6,
+    'ESP32S2': 0xbfdd4eee
 }
 
 INFO_FILE = "/INFO_UF2.TXT"
@@ -93,7 +94,8 @@ def convert_from_uf2(buf):
     return b"".join(outp)
 
 def convert_to_carray(file_content):
-    outp = "const unsigned char bindata[] __attribute__((aligned(16))) = {"
+    outp = "const unsigned long bindata_len = %d;\n" % len(file_content)
+    outp += "const unsigned char bindata[] __attribute__((aligned(16))) = {"
     for i in range(len(file_content)):
         if i % 16 == 0:
             outp += "\n"

--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -94,8 +94,7 @@ def convert_from_uf2(buf):
     return b"".join(outp)
 
 def convert_to_carray(file_content):
-    outp = "const unsigned long bindata_len = %d;\n" % len(file_content)
-    outp += "const unsigned char bindata[] __attribute__((aligned(16))) = {"
+    outp = "const unsigned char bindata[] __attribute__((aligned(16))) = {"
     for i in range(len(file_content)):
         if i % 16 == 0:
             outp += "\n"


### PR DESCRIPTION
This PR add ESP32S2 family `0xbfdd4eee` which is generated randomly with recommended [patcher script](https://microsoft.github.io/uf2/patcher/) and currently is used by https://github.com/adafruit/tinyuf2 for esp32s2. 

~This also adds `bindata_len` for carray coversion which is very handy for platform where the actual bootloader size is desired.~ 

~PS: I am piggy packed 2 features in one PR since the modification is simple enough. Let me know if you want to separate them or want to make any adjustment.~

