### PR TITLE
add bindata_len in carray conversion

### DIFF
--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -93,7 +93,8 @@ def convert_from_uf2(buf):
     return b"".join(outp)
 
 def convert_to_carray(file_content):
-    outp = "const unsigned char bindata[] __attribute__((aligned(16))) = {"
+    outp = "const unsigned long bindata_len = %d;\n" % len(file_content)
+    outp += "const unsigned char bindata[] __attribute__((aligned(16))) = {"
     for i in range(len(file_content)):
         if i % 16 == 0:
             outp += "\n"


### PR DESCRIPTION
This PR adds `bindata_len` for carray coversion which is very handy for platform where the actual bootloader size is desired. Following is example output

```
const unsigned long bindata_len = 127760;
const unsigned char bindata[] __attribute__((aligned(16))) = {
0xe9, 0x06, 0x02, 0x2f, 0xa8, 0x2d, 0x02, 0x40, 0xee, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
```