### PR TITLE
Add RP2040 family ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ This procedure was unfortunately not used for the SAMD51 and NRF52840 below.
 * NXP i.MX RT10XX - 0x4fb2d5bd
 * NXP LPC55xx - 0x2abc77ec
 * GD32F350 - 0x31d228c6
+* Raspberry Pi RP2040 - 0xe48bff56
 
 ### Rationale
 

--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -36,7 +36,8 @@ families = {
     'MIMXRT10XX': 0x4FB2D5BD,
     'LPC55': 0x2abc77ec,
     'GD32F350': 0x31D228C6,
-    'ESP32S2': 0xbfdd4eee
+    'ESP32S2': 0xbfdd4eee,
+    'RP2040': 0xe48bff56
 }
 
 INFO_FILE = "/INFO_UF2.TXT"


### PR DESCRIPTION
Hi,

This PR adds a UF2 ID for RP2040. We generated the ID randomly using the recommended bash expression.

The UF2 bootloader is in the boot ROM, so unfortunately we can't change the ID at this point.