### PR TITLE
avoid misleading status message

### DIFF
--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -296,8 +296,9 @@ def main():
             ext = "h"
         else:
             outbuf = convert_to_uf2(inpbuf)
-        print("Converting to %s, output size: %d, start address: 0x%x" %
-              (ext, len(outbuf), appstartaddr))
+        if not args.deploy:
+            print("Converted to %s, output size: %d, start address: 0x%x" %
+                  (ext, len(outbuf), appstartaddr))
         if args.convert or ext != "uf2":
             drives = []
             if args.output == None:


### PR DESCRIPTION
When invoked to deploy a uf2 image this currently emits something like

   Converting to uf2, output size: 36864, start address: 0x2000

which misrepresents both the size and the start address and suggests
more conversion is happening.  Don't print anything about converting
in this case; also change to "converted" since the message is
displayed after the conversion completes.