### PR TITLE
Add GigaDevice GD32VF103 family ids

### DIFF
--- a/utils/uf2families.json
+++ b/utils/uf2families.json
@@ -183,5 +183,10 @@
         "id": "0x00ff6919",
         "short_name": "STM32L4",
         "description": "ST STM32L4xx"
+    },
+    {
+        "id": "0x9af03e33",
+        "short_name": "GD32VF103",
+        "description": "GigaDevice GD32VF103"
     }
 ]


### PR DESCRIPTION
Working on a [tinyuf2 implementation](https://github.com/KarlK90/tinyuf2/tree/gd32vf103-support) for that chip, which is already functional. The family id was generated via CF2 patcher.
 