### PR TITLE
Print uf2conv errors to stderr instead of stdout

### DIFF
--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -267,7 +267,7 @@ def load_families():
 def main():
     global appstartaddr, familyid
     def error(msg):
-        print(msg)
+        print(msg, file=sys.stderr)
         sys.exit(1)
     parser = argparse.ArgumentParser(description='Convert to UF2 or flash directly.')
     parser.add_argument('input', metavar='INPUT', type=str, nargs='?',


### PR DESCRIPTION
Basically what it says in the title. Use case for me is that I can easily discard or redirect error messages and only want pass on the stdout messages to the user.