### PR TITLE
utils/uf2conv.py: Fix padding with Python3

### DIFF
--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -73,7 +73,7 @@ def convert_from_uf2(buf):
             assert False, "Non-word padding size at " + ptr
         while padding > 0:
             padding -= 4
-            outp += b"\x00\x00\x00\x00"
+            outp.append(b"\x00\x00\x00\x00")
         if familyid == 0x0 or ((hd[2] & 0x2000) and familyid == hd[7]):
             outp.append(block[32 : 32 + datalen])
         curraddr = newaddr + datalen


### PR DESCRIPTION
Reproduce with:

```
echo -n foo12345679 > foo
echo -n bar12345679 > bar

./utils/uf2conv.py foo -c -b 0x100 -o foo.uf2
./utils/uf2conv.py bar -c -b 0x1000 -o bar.uf2

cat foo.uf2 bar.uf2 > combined.uf2
./utils/uf2conv.py -i combined.uf2
```

Would fail like this
```
--- UF2 File Header Info ---
All block flag values consistent, 0x0000
----------------------------
Traceback (most recent call last):
  File "/home/zoid/clone/uf2/./utils/uf2conv.py", line 360, in <module>
    main()
  File "/home/zoid/clone/uf2/./utils/uf2conv.py", line 328, in main
    convert_from_uf2(inpbuf)
  File "/home/zoid/clone/uf2/./utils/uf2conv.py", line 109, in convert_from_uf2
    return b"".join(outp)
TypeError: sequence item 1: expected a bytes-like object, int found
```