### PR TITLE
Add family ID for Sipeed MaixPlay-U4

### DIFF
--- a/utils/uf2families.json
+++ b/utils/uf2families.json
@@ -203,5 +203,10 @@
         "id": "0x11de784a",
         "short_name": "M0SENSE",
         "description": "M0SENSE BL702"
+    },
+    {
+        "id": "0x4b684d71",
+        "short_name": "MaixPlay-U4",
+        "description": "Sipeed MaixPlay-U4(BL618)"
     }
 ]


### PR DESCRIPTION
As the title, this PR adds a UF2 family ID for Sipeed MaixPlay-U4. We generated the ID randomly using the recommended bash expression.