### PR TITLE
utils/uf2conv.py: Search for additional deployment locations

### DIFF
--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -220,9 +220,9 @@ def get_drives():
 
         for rootpath in searchpaths:
             if os.path.isdir(rootpath):
-                for d in os.scandir(rootpath):
-                    if d.is_dir():
-                        drives.append(d.path)
+                for d in os.listdir(rootpath):
+                    if os.path.isdir(rootpath):
+                        drives.append(os.path.join(rootpath, d))
 
 
     def has_info(d):

--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -212,15 +212,17 @@ def get_drives():
             if len(words) >= 3 and words[1] == "2" and words[2] == "FAT":
                 drives.append(words[0])
     else:
-        rootpath = "/media"
+        searchpaths = ["/media"]
         if sys.platform == "darwin":
-            rootpath = "/Volumes"
+            searchpaths = ["/Volumes"]
         elif sys.platform == "linux":
-            tmp = rootpath + "/" + os.environ["USER"]
-            if os.path.isdir(tmp):
-                rootpath = tmp
-        for d in os.listdir(rootpath):
-            drives.append(os.path.join(rootpath, d))
+            searchpaths += ["/media/" + os.environ["USER"], '/run/media/' + os.environ["USER"]]
+
+        for rootpath in searchpaths:
+            if os.path.isdir(rootpath):
+                for d in os.scandir(rootpath):
+                    if d.is_dir():
+                        drives.append(d.path)
 
 
     def has_info(d):


### PR DESCRIPTION
[QMK](https://github.com/qmk/qmk_firmware) currently uses `uf2conf.py` as part of its workflow to convert and eventually deploy firmware. It was noted by a few users on our Discord that on some Linux distributions, it failed to find the auto-mounted directory.

This PR adds the additional search directory `/run/media/<user>/` while also filtering to ensure the end list is only directories, and handling the uncaught exception when `/media/` does not exist.