### PR TITLE
Added Renesas RZA1LU to families.

### DIFF
--- a/utils/uf2families.json
+++ b/utils/uf2families.json
@@ -208,5 +208,10 @@
         "id": "0x4b684d71",
         "short_name": "MaixPlay-U4",
         "description": "Sipeed MaixPlay-U4(BL618)"
+    },
+    {
+        "id": "0x9517422f",
+        "short_name": "RZA1LU",
+        "description": "Renesas RZ/A1LU (R7S7210xx)"
     }
 ]


### PR DESCRIPTION
Working on getting uf2 loading working with the Renesas RZ/A1LU (cortex_a). Added back to families.