### PR TITLE
add IDs for ESP32-C6 and ESP32-P4

### DIFF
--- a/utils/uf2families.json
+++ b/utils/uf2families.json
@@ -175,6 +175,16 @@
         "description": "ESP32-H2"
     },
     {
+        "id": "0x540ddf62",
+        "short_name": "ESP32C6",
+        "description": "ESP32-C6"
+    },
+    {
+        "id": "0x3d308e94",
+        "short_name": "ESP32P4",
+        "description": "ESP32-P4"
+    },
+    {
         "id": "0xe48bff56",
         "short_name": "RP2040",
         "description": "Raspberry Pi RP2040"


### PR DESCRIPTION
The IDs were generated by the random number generator at https://microsoft.github.io/uf2/patcher.