### PR TITLE
add IDs for stm32f411xE stm32f411xC nrf52832xxAA nrf52832xxAB

### DIFF
--- a/utils/uf2families.json
+++ b/utils/uf2families.json
@@ -223,5 +223,25 @@
         "id": "0x9517422f",
         "short_name": "RZA1LU",
         "description": "Renesas RZ/A1LU (R7S7210xx)"
+    },
+    {
+        "id": "0x2dc309c5",
+        "short_name": "STM32F411xE",
+        "description": "ST STM32F411xE"
+    },
+    {
+        "id": "0x06d1097b",
+        "short_name": "STM32F411xC",
+        "description": "ST STM32F411xC"
+    },
+    {
+        "id": "0x72721d4e",
+        "short_name": "NRF52832xxAA",
+        "description": "Nordic NRF52832xxAA"
+    },
+    {
+        "id": "0x6f752678",
+        "short_name": "NRF52832xxAB",
+        "description": "Nordic NRF52832xxAB"
     }
 ]


### PR DESCRIPTION
I have written a UF2 upgrade program for STM32F411 and nRF52832. The nRF52832 does not have USB functionality, but it can be connected to the STM32F411 through a UART port. After the STM32F411 detects the UF2 blocks from nRF52832, it transfers them to the nRF52832 via the UART port.
I achieved the upgrade for both chips by copying the combined UF2 file for STM32F411 and nRF52832 onto the msc device of the upgraded version of STM32F411. Therefore, an ID needs to be assigned for the nRF52832 as well.
I believe that different chips with different memory capacities should be assigned different IDs. For example, STM32F411xE and STM32F411xC, nRF52832xxAA and nRF52832xxAB.