### PR TITLE
Use raw strings for Python regexps to avoid Python 3.12 error

### DIFF
--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -29,7 +29,7 @@ def is_hex(buf):
         w = buf[0:30].decode("utf-8")
     except UnicodeDecodeError:
         return False
-    if w[0] == ':' and re.match(b"^[:0-9a-fA-F\r\n]+$", buf):
+    if w[0] == ':' and re.match(rb"^[:0-9a-fA-F\r\n]+$", buf):
         return True
     return False
 
@@ -208,7 +208,7 @@ def get_drives():
                                      "get", "DeviceID,", "VolumeName,",
                                      "FileSystem,", "DriveType"])
         for line in to_str(r).split('\n'):
-            words = re.split('\s+', line)
+            words = re.split(r'\s+', line)
             if len(words) >= 3 and words[1] == "2" and words[2] == "FAT":
                 drives.append(words[0])
     else:
@@ -237,7 +237,7 @@ def get_drives():
 def board_id(path):
     with open(path + INFO_FILE, mode='r') as file:
         file_content = file.read()
-    return re.search("Board-ID: ([^\r\n]*)", file_content).group(1)
+    return re.search(r"Board-ID: ([^\r\n]*)", file_content).group(1)
 
 
 def list_drives():


### PR DESCRIPTION
In Python 3.12, unrecognized escape sequences now raise `SyntaxWarning`. So this line
https://github.com/microsoft/uf2/blob/17e70bf908e6abdf4f4acc50a9c84e5709ded2a9/utils/uf2conv.py#L211
is now erroneous: it needs to be `r'\s+'`.

Changed all regexps to be raw strings to avoid this problem for Python 3.12 and later.

This repo is used as a submodule in various downstream repos like [`uf2-samd21`](https://github.com/microsoft/uf2-samdx1), so those will need to be updated too.

@ladyada for interest