### PR TITLE
add IDs for ESP32-C5 and ESP32-C61

### DIFF
--- a/utils/uf2families.json
+++ b/utils/uf2families.json
@@ -185,6 +185,16 @@
         "description": "ESP32-P4"
     },
     {
+        "id": "0xf71c0343",
+        "short_name": "ESP32C5",
+        "description": "ESP32-C5"
+    },
+    {
+        "id": "0x77d850c4",
+        "short_name": "ESP32C61",
+        "description": "ESP32-C61"
+    },
+    {
         "id": "0xe48bff56",
         "short_name": "RP2040",
         "description": "Raspberry Pi RP2040"


### PR DESCRIPTION
IDs were generated by the random number generator at https://microsoft.github.io/uf2/patcher.

For reference:
- ESP32-C5: https://www.espressif.com/en/news/ESP32-C5
- ESP32-C61: https://www.espressif.com/en/news/ESP32-C61_SoC