### PR TITLE
Reserve family ID for WCH CH32V

### DIFF
--- a/utils/uf2families.json
+++ b/utils/uf2families.json
@@ -258,5 +258,10 @@
         "id": "0xa0c97b8e",
         "short_name": "AT32F415",
         "description": "ArteryTek AT32F415"
+    },
+    {
+        "id": "0x699b62ec",
+        "short_name": "CH32V",
+        "description": "WCH CH32V2xx and CH32V3xx"
     }
 ]


### PR DESCRIPTION
The CH32V2xx and CH32V3xx series are RISC-V microcontrollers from Nanjing Qinheng Microelectronics (南京沁恒微电子). Their English website is at https://www.wch-ic.com/ .

I've written a UF2 bootloader for these parts (tested on the CH32V203C8T6, but the entire family seems to have a mostly-consistent memory map and the same flash interface) which I will be releasing in the next few days (after some code/docs cleanup) and want to reserve this family ID.