### PR TITLE
Add UF2 families for RP2350

### DIFF
--- a/utils/uf2families.json
+++ b/utils/uf2families.json
@@ -200,6 +200,31 @@
         "description": "Raspberry Pi RP2040"
     },
     {
+        "id": "0xe48bff57",
+        "short_name": "RP2XXX_ABSOLUTE",
+        "description": "Raspberry Pi Microcontrollers: Absolute (unpartitioned) download"
+    },
+    {
+        "id": "0xe48bff58",
+        "short_name": "RP2XXX_DATA",
+        "description": "Raspberry Pi Microcontrollers: Data partition download"
+    },
+    {
+        "id": "0xe48bff59",
+        "short_name": "RP2350_ARM_S",
+        "description": "Raspberry Pi RP2350, Secure Arm image"
+    },
+    {
+        "id": "0xe48bff5a",
+        "short_name": "RP2350_RISCV",
+        "description": "Raspberry Pi RP2350, RISC-V image"
+    },
+    {
+        "id": "0xe48bff5b",
+        "short_name": "RP2350_ARM_NS",
+        "description": "Raspberry Pi RP2350, Non-secure Arm image"
+    },
+    {
         "id": "0x00ff6919",
         "short_name": "STM32L4",
         "description": "ST STM32L4xx"


### PR DESCRIPTION
This PR adds a small number of UF2 family IDs for the new RP2350 microcontroller. They are used in mask ROM.

For code size reasons they are assigned sequentially from the RP2040 ID. Hopefully this is not an issue as the initial RP2040 ID was assigned randomly.