### PR TITLE
Add UF2 families for Realtek, Beken, Boufallo and Xradiotech

### DIFF
--- a/utils/uf2families.json
+++ b/utils/uf2families.json
@@ -35,6 +35,11 @@
         "description": "ST STM32WLxx"
     },
     {
+        "id": "0x22e0d6fc",
+        "short_name": "RTL8710B",
+        "description": "Realtek AmebaZ RTL8710B"
+    },
+    {
         "id": "0x2abc77ec",
         "short_name": "LPC55",
         "description": "NXP LPC55xx"
@@ -50,6 +55,11 @@
         "description": "GD32F350"
     },
     {
+        "id": "0x3379CFE2",
+        "short_name": "RTL8720D",
+        "description": "Realtek AmebaD RTL8720D"
+    },
+    {
         "id": "0x04240bdf",
         "short_name": "STM32L5",
         "description": "ST STM32L5xx"
@@ -63,6 +73,11 @@
         "id": "0x4fb2d5bd",
         "short_name": "MIMXRT10XX",
         "description": "NXP i.MX RT10XX"
+    },
+    {
+        "id": "0x51e903a8",
+        "short_name": "XR809",
+        "description": "Xradiotech 809"
     },
     {
         "id": "0x53b80f00",
@@ -105,9 +120,19 @@
         "description": "ST STM32F0xx"
     },
     {
+        "id": "0x675a40b0",
+        "short_name": "BK7231U",
+        "description": "Beken 7231U/7231T"
+    },
+    {
         "id": "0x68ed2b88",
         "short_name": "SAMD21",
         "description": "Microchip (Atmel) SAMD21"
+    },
+    {
+        "id": "0x6a82cc42",
+        "short_name": "BK7251",
+        "description": "Beken 7251/7252"
     },
     {
         "id": "0x6b846188",
@@ -130,6 +155,11 @@
         "description": "ST STM32WBxx"
     },
     {
+        "id": "0x7b3ef230",
+        "short_name": "BK7231N",
+        "description": "Beken 7231N"
+    },
+    {
         "id": "0x7eab61ed",
         "short_name": "ESP8266",
         "description": "ESP8266"
@@ -143,6 +173,11 @@
         "id": "0x8fb060fe",
         "short_name": "STM32F407VG",
         "description": "ST STM32F407VG"
+    },
+    {
+        "id": "0x9fffd543",
+        "short_name": "RTL8710A",
+        "description": "Realtek Ameba1 RTL8710A"
     },
     {
         "id": "0xada52840",
@@ -193,6 +228,16 @@
         "id": "0x77d850c4",
         "short_name": "ESP32C61",
         "description": "ESP32-C61"
+    },
+    {
+        "id": "0xde1270b7",
+        "short_name": "BL602",
+        "description": "Boufallo 602"
+    },
+    {
+        "id": "0xe08f7564",
+        "short_name": "RTL8720C",
+        "description": "Realtek AmebaZ2 RTL8720C"
     },
     {
         "id": "0xe48bff56",


### PR DESCRIPTION
ESPHome builds rtl8710bx firmware as an UF2 file. I noticed RTL8710B family is not in `uf2families.json`.

I found this mapping in libretuya project: https://github.com/blakadder/libretuya/blob/f63a11437126081dac49166bfa760403f8adbcd1/arduino/libretuya/core/ChipType.h#L10