### PR TITLE
Add generic family id for Nordic nRF52820_xxAA series.

### DIFF
--- a/utils/uf2families.json
+++ b/utils/uf2families.json
@@ -190,6 +190,11 @@
         "description": "Nordic NRF52840"
     },
     {
+        "id": "0x820d9a5f",
+        "short_name": "NRF52820",
+        "description": "Nordic NRF52820_xxAA"
+    },
+    {
         "id": "0xbfdd4eee",
         "short_name": "ESP32S2",
         "description": "ESP32-S2"


### PR DESCRIPTION
This PR add a random family id (0x820d9a5f) for Nordic nRF52820_xxAA series.
This ID is generated randomly from https://microsoft.github.io/uf2/patcher/