### PR TITLE
add missing flagh defines to uf2.h

### DIFF
--- a/uf2.h
+++ b/uf2.h
@@ -40,7 +40,11 @@ SOFTWARE.
 #define UF2_MAGIC_END 0x0AB16F30UL    // Ditto
 
 // If set, the block is "comment" and should not be flashed to the device
-#define UF2_FLAG_NOFLASH 0x00000001
+#define UF2_FLAG_NOFLASH        0x00000001
+#define UF2_FLAG_FILECONTAINER  0x00001000 // fle container
+#define UF2_FLAG_FAMILY_ID      0x00002000 // familyID present
+#define UF2_FLAG_MD5_CHKSUM     0x00004000 // MD5 checksum present
+#define UF2_FLAG_EXTENSION_TAGS 0x00008000 // extension tags present
 
 typedef struct {
     // 32 byte header


### PR DESCRIPTION
This PR adds defines for the flags described in README.md to uf2.h.
This way impementations do not have to define those outside of uf2.h, when the UF2 repository is added to a project as a submodule.