### PR TITLE
Set the UF2 blocks default data to 0xFF.

### DIFF
--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -141,9 +141,9 @@ def convert_to_uf2(file_content):
     return b"".join(outp)
 
 class Block:
-    def __init__(self, addr):
+    def __init__(self, addr, default_data=0xFF):
         self.addr = addr
-        self.bytes = bytearray(256)
+        self.bytes = bytearray([default_data] * 256)
 
     def encode(self, blockno, numblocks):
         global familyid


### PR DESCRIPTION
This is the default flash state in the majority of MCUs.

Fixes https://github.com/microsoft/uf2/issues/92.