### PR TITLE
Add IDs for ESP32-H21 and ESP32-H4

### DIFF
--- a/utils/uf2families.json
+++ b/utils/uf2families.json
@@ -240,6 +240,16 @@
         "description": "ESP32-C61"
     },
     {
+        "id": "0xb6dd00af",
+        "short_name": "ESP32H21",
+        "description": "ESP32-H21"
+    },
+    {
+        "id": "0x9e0baa8a",
+        "short_name": "ESP32H4",
+        "description": "ESP32-H4"
+    },
+    {
         "id": "0xde1270b7",
         "short_name": "BL602",
         "description": "Boufallo 602"


### PR DESCRIPTION
- Added new IDs for the ESP32-H21 and ESP32-H4 additions to the ESP32 family.
- The random number generator at https://microsoft.github.io/uf2/patcher was used to generate the IDs.