### PR TITLE
uf2conv: add more searchpaths, fix pathcheck

### DIFF
--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -212,16 +212,19 @@ def get_drives():
             if len(words) >= 3 and words[1] == "2" and words[2] == "FAT":
                 drives.append(words[0])
     else:
-        searchpaths = ["/media"]
+        searchpaths = ["/mnt", "/media"]
         if sys.platform == "darwin":
             searchpaths = ["/Volumes"]
         elif sys.platform == "linux":
-            searchpaths += ["/media/" + os.environ["USER"], '/run/media/' + os.environ["USER"]]
+            searchpaths += ["/media/" + os.environ["USER"], "/run/media/" + os.environ["USER"]]
+            if "SUDO_USER" in os.environ.keys():
+                searchpaths += ["/media/" + os.environ["SUDO_USER"]]
+                searchpaths += ["/run/media/" + os.environ["SUDO_USER"]]
 
         for rootpath in searchpaths:
             if os.path.isdir(rootpath):
                 for d in os.listdir(rootpath):
-                    if os.path.isdir(rootpath):
+                    if os.path.isdir(os.path.join(rootpath, d)):
                         drives.append(os.path.join(rootpath, d))
 
 


### PR DESCRIPTION
Hello everyone,

the RIOT OS uses the `uf2conv.py` script to program devices with the Adafruit nRF52 Bootloader.
Today we noticed some quirks:
1) Some distributions that don't necessarily use an automounter by default (like Arch Linux) don't necessarily use `/media` to mount devices but the more "tradutional" mount point `/mnt`. The `uf2conv.py` script currently does not search there.

2) When running `uf2conv.py` as root via `sudo`, it won't find any devices mounted by the user. This is because currently only the paths with `/media/${USER}` are checked. However `${USER}==root` when using `sudo`. Therefore this PR adds a check if `SUDO_USER` is defined in the environment and adds `/media/${SUDO_USER}` to the search path.

```
chris@W11nMate:~$ sudo python3
[sudo] password for chris:
Python 3.10.12 (main, Feb  4 2025, 14:57:36) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.environ
environ({'LANG': 'C.UTF-8', 'LS_COLORS': '...', 'TERM': 'xterm-256color', 'DISPLAY': ':0',
'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin', 'MAIL': '/var/mail/root', '
LOGNAME': 'root', 'USER': 'root', 'HOME': '/root', 'SHELL': '/bin/bash', 'SUDO_COMMAND': '/usr/bin/python3', 
'SUDO_USER': 'chris', 'SUDO_UID': '1000', 'SUDO_GID': '1000'})
>>>
```

3) One of our students noticed that the `os.path.isdir(rootpath)` check is redundant. I guess that that like should've been `os.path.isdir(os.path.join(rootpath, d))` to see if the path is valid before adding it to the `drives` variable.

Best Regards,
Chris