### PR TITLE
utils/uf2conv.py: Use powershell instead of wmic

### DIFF
--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -204,13 +204,14 @@ def to_str(b):
 def get_drives():
     drives = []
     if sys.platform == "win32":
-        r = subprocess.check_output(["wmic", "PATH", "Win32_LogicalDisk",
-                                     "get", "DeviceID,", "VolumeName,",
-                                     "FileSystem,", "DriveType"])
-        for line in to_str(r).split('\n'):
-            words = re.split(r'\s+', line)
-            if len(words) >= 3 and words[1] == "2" and words[2] == "FAT":
-                drives.append(words[0])
+        r = subprocess.check_output([
+            "powershell",
+            "-Command",
+            '(Get-WmiObject Win32_LogicalDisk -Filter "VolumeName=\'RPI-RP2\'").DeviceID'
+            ])
+        drive = to_str(r).strip()
+        if drive:
+            drives.append(drive)
     else:
         searchpaths = ["/mnt", "/media"]
         if sys.platform == "darwin":


### PR DESCRIPTION
wmic command was removed in Windows 24H2, so it's not available on most systems these days by default. However, powershell is.