### PR TITLE
Add ESP32-S31 ID

### DIFF
--- a/utils/uf2families.json
+++ b/utils/uf2families.json
@@ -250,6 +250,11 @@
         "description": "ESP32-H4"
     },
     {
+        "id": "0x3101f7c1",
+        "short_name": "ESP32S31",
+        "description": "ESP32-S31"
+    },
+    {
         "id": "0xde1270b7",
         "short_name": "BL602",
         "description": "Boufallo 602"


### PR DESCRIPTION
- Added new ID for the ESP32-S31 addition to the ESP32 family.
- The random number generator at https://microsoft.github.io/uf2/patcher was used to generate the IDs.